### PR TITLE
Linux support and holiday info

### DIFF
--- a/swe-holiday-prompt.zsh
+++ b/swe-holiday-prompt.zsh
@@ -22,17 +22,39 @@ setopt PROMPT_SUBST
 # The format of the map key (date) should be `date +"%m%d"`
 typeset -A holidays
 
+# Helper function to calculate the start and end timestamps based on OS
+# Check for MacOS and if it isn't assume it's Linux
+_calculate_range() {
+  if [ "$(uname)" = "Darwin" ]; then
+    echo $(date -j -f "%Y%m%d" $1 "+%s")
+  else
+    echo $(date -d "$1" "+%s")
+  fi
+}
+
+# Helper function to convert a timestamp to a month-day key based on OS
+# Check for MacOS and if it isn't assume it's Linux
+_convert_to_key() {
+  if [ "$(uname)" = "Darwin" ]; then
+    echo $(date -j -f "%s" $1 "+%m%d")
+  else
+    echo $(date -d "@$1" "+%m%d")
+  fi
+}
+
 # Adds a range of dates to the map of emojis. Takes 3 arguments
 # _add_range <start> <end> <emoji>
 _add_range() {
   _year=$(date +"%Y")
-  _starts=$(date -j -f "%Y%m%d" $_year$1 "+%s")
-  _ends=$(date -j -f "%Y%m%d" $_year$2 "+%s")
   _icon=$3
-  _count=$((($_ends-$_starts)/86400+1))
+
+  _starts=$(_calculate_range "${_year}$1")
+  _ends=$(_calculate_range "${_year}$2")
+  _count=$((($_ends - $_starts) / 86400 + 1))
+
   for i in $(seq $_count); do
-    _add_starts=$(($_starts+86400*($i-1)))
-    _key=$(date -j -f "%s" $_add_starts +"%m%d")
+    _add_starts=$(($_starts + 86400 * (i - 1)))
+    _key=$(_convert_to_key $_add_starts)
     holidays[$_key]=$_icon
   done
 }
@@ -65,7 +87,7 @@ _add_range 0601 0605 🌼
 _add_range 0606 0607 🇸🇪
 
 # Midsommar (hela juni)
-_add_range 0608 0631 ☀️
+_add_range 0608 0630 ☀️
 
 # Alla helgons dag (månadsskiftet oktober-november)
 _add_range 1030 1102 👻

--- a/swe-holiday-prompt.zsh
+++ b/swe-holiday-prompt.zsh
@@ -47,6 +47,7 @@ _convert_to_key() {
 _add_range() {
   _year=$(date +"%Y")
   _icon=$3
+  _description=$4
 
   _starts=$(_calculate_range "${_year}$1")
   _ends=$(_calculate_range "${_year}$2")
@@ -55,62 +56,73 @@ _add_range() {
   for i in $(seq $_count); do
     _add_starts=$(($_starts + 86400 * (i - 1)))
     _key=$(_convert_to_key $_add_starts)
-    holidays[$_key]=$_icon
+    holidays[$_key]="$_icon|$_description"
   done
 }
 
 # New year
-_add_range 0101 0102 🤢
+_add_range 0101 0102 🤢 "Nyårsdagen"
 
 # Easter
-_add_range 0322 0425 🐣
+_add_range 0322 0425 🐣 "Påsk"
 
 # TODO: Fettisdagen (tisdagen efter fastlagssöndagen) 🥯
 
 # Våffeldagen
-_add_range 0325 0326 🧇
+_add_range 0325 0326 🧇 "Våffeldagen - nom nom!"
 
 # Valborgsmässoafton
-_add_range 0430 0430 🔥
+_add_range 0430 0430 🔥 "Valborgsmässoafton"
 
 # 1a Maj
-_add_range 0430 0430 🟥
+_add_range 0430 0430 🟥 "1a Maj"
 
 # TODO: Kristi himmelfärdsdag (40 dagar efter påsk) 🕊️
 
 # TODO: Pingst (10 dagar efter kristi himmelfärdsdagen) ✝️
 
 # Midsommar (hela juni)
-_add_range 0601 0605 🌼
+_add_range 0601 0605 🌼 "Midsommar"
 
 # Sveriges nationaldag
-_add_range 0606 0607 🇸🇪
+_add_range 0606 0607 🇸🇪 "Nationaldagen"
 
 # Midsommar (hela juni)
-_add_range 0608 0630 ☀️
+_add_range 0608 0630 ☀️ "Midsommar"
 
 # Alla helgons dag (månadsskiftet oktober-november)
-_add_range 1030 1102 👻
+_add_range 1030 1102 👻 "Alla helgons dag"
 
 # Advent (slutet av november-december)
-_add_range 1130 1201 🕯️
+_add_range 1130 1201 🕯️ "Advent (of code?)"
 
 # Lucia
-_add_range 1213 1213 👸
+_add_range 1213 1213 👸 "Lucia"
 
 # Christmas
-_add_range 1214 1223 🎄
-_add_range 1224 1225 🎁 
-_add_range 1226 1229 🎄
-_add_range 1230 1230 🥳
+_add_range 1214 1223 🎄 "Jul"
+_add_range 1224 1225 🎁 "Jul"
+_add_range 1226 1229 🎄 "Strålande jul"
+_add_range 1230 1230 🥳 "Nyårsafton"
+
+# Print which holiday it is
+swe_holiday() {
+  d=$(date +"%m%d")
+  h=${holidays[$d]}
+  desc=${h#*|}
+
+  print $desc
+}
 
 # Main func
 swe_prompt() {
   d=$(date +"%m%d")
-  prompt="${holidays[$d]}"
+  h=${holidays[$d]}
+  e=${h%%|*}
+
+  prompt=$e
   if [ ! -z $prompt ]; then
     prompt+=" "
   fi
   print "${prompt}"
 }
-

--- a/swe-holiday-prompt.zsh
+++ b/swe-holiday-prompt.zsh
@@ -42,8 +42,8 @@ _convert_to_key() {
   fi
 }
 
-# Adds a range of dates to the map of emojis. Takes 3 arguments
-# _add_range <start> <end> <emoji>
+# Adds a range of dates to the map of emojis. Takes 4 arguments
+# _add_range <start> <end> <emoji> <description>
 _add_range() {
   _year=$(date +"%Y")
   _icon=$3

--- a/swe-holiday-prompt.zsh
+++ b/swe-holiday-prompt.zsh
@@ -25,7 +25,7 @@ typeset -A holidays
 # Helper function to calculate the start and end timestamps based on OS
 # Check for MacOS and if it isn't assume it's Linux
 _calculate_range() {
-  if [ "$(uname)" = "Darwin" ]; then
+  if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "FreeBSD" ]; then
     echo $(date -j -f "%Y%m%d" $1 "+%s")
   else
     echo $(date -d "$1" "+%s")
@@ -35,7 +35,7 @@ _calculate_range() {
 # Helper function to convert a timestamp to a month-day key based on OS
 # Check for MacOS and if it isn't assume it's Linux
 _convert_to_key() {
-  if [ "$(uname)" = "Darwin" ]; then
+  if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "FreeBSD" ]; then
     echo $(date -j -f "%s" $1 "+%m%d")
   else
     echo $(date -d "@$1" "+%m%d")


### PR DESCRIPTION
This PR adds support for Linux while keeping the Mac support intact. The linux version of the date commands fails if a range is invalid so I noticed that the end date for june was incorrect, fixed that as well.

I also added a description to each holiday that you can print with "swe_holiday" command in your shell. 

The description functionality is in another commit so if you just want the linux support you can cerry-pick that commit :) 